### PR TITLE
Added more go versions to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ go:
 matrix:
   allow_failures:
     - go: tip
+    - go: 1.2
+    - go: 1.3
 
 install:
   - go get golang.org/x/tools/cmd/vet

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,15 @@ env:
 language: go
 
 go:
+  - 1.2
+  - 1.3
+  - 1.4
   - 1.5
+  - tip
+
+matrix:
+  allow_failures:
+    - go: tip
 
 install:
   - go get golang.org/x/tools/cmd/vet
@@ -22,3 +30,4 @@ install:
 script:
   - go vet -x ./...
   - ./coverage --coveralls
+


### PR DESCRIPTION
Happy New Year,

This change adds additional builds to the build matrix.

Go version 1.2 and 1.3 are still supported by Ubuntu 14.04 LTS.
So, even though go users tend to use the latest stable it would
be nice to know at a glance that this library is passing for legacy
users.

Go tip has also been added and placed under allowed failures for
bleeding edge users as well.