### PR TITLE
Include user session data in all calls to storage handlers

### DIFF
--- a/handler/core/client/client.go
+++ b/handler/core/client/client.go
@@ -50,7 +50,7 @@ func (c *ClientCredentialsGrantHandler) HandleTokenEndpointRequest(ctx context.C
 	access, err := c.Enigma.GenerateChallenge(requester.GetClient().GetHashedSecret())
 	if err != nil {
 		return errors.New(fosite.ErrServerError)
-	} else if err := c.Store.CreateAccessTokenSession(access.Signature, requester, &core.TokenSession{}); err != nil {
+	} else if err := c.Store.CreateAccessTokenSession(access.Signature, requester, &core.TokenSession{Extra: session}); err != nil {
 		return errors.New(fosite.ErrServerError)
 	}
 

--- a/handler/core/explicit/explicit_token.go
+++ b/handler/core/explicit/explicit_token.go
@@ -23,7 +23,7 @@ func (c *AuthorizeExplicitGrantTypeHandler) ValidateTokenEndpointRequest(_ conte
 		return nil
 	}
 
-	var authSess AuthorizeSession
+	authSess := AuthorizeSession{Extra: session}
 	challenge := &enigma.Challenge{}
 	challenge.FromString(req.PostForm.Get("code"))
 
@@ -102,10 +102,9 @@ func (c *AuthorizeExplicitGrantTypeHandler) HandleTokenEndpointRequest(ctx conte
 		return errors.New(ErrServerError)
 	}
 
-	var authSess AuthorizeSession
 	challenge := &enigma.Challenge{}
 	challenge.FromString(req.PostForm.Get("code"))
-	ar, err := c.Store.GetAuthorizeCodeSession(challenge.Signature, &authSess)
+	ar, err := c.Store.GetAuthorizeCodeSession(challenge.Signature, &AuthorizeSession{Extra: session})
 	if err != nil {
 		// The signature has already been verified both cryptographically and with lookup. If lookup fails here
 		// it is due to some internal error.
@@ -114,9 +113,9 @@ func (c *AuthorizeExplicitGrantTypeHandler) HandleTokenEndpointRequest(ctx conte
 
 	if err := c.Store.DeleteAuthorizeCodeSession(req.PostForm.Get("code")); err != nil {
 		return errors.New(ErrServerError)
-	} else if err := c.Store.CreateAccessTokenSession(access.Signature, requester, &core.TokenSession{}); err != nil {
+	} else if err := c.Store.CreateAccessTokenSession(access.Signature, requester, &core.TokenSession{Extra: session}); err != nil {
 		return errors.New(ErrServerError)
-	} else if err := c.Store.CreateRefreshTokenSession(refresh.Signature, requester, &core.TokenSession{}); err != nil {
+	} else if err := c.Store.CreateRefreshTokenSession(refresh.Signature, requester, &core.TokenSession{Extra: session}); err != nil {
 		return errors.New(ErrServerError)
 	}
 

--- a/handler/core/owner/owner.go
+++ b/handler/core/owner/owner.go
@@ -55,7 +55,7 @@ func (c *ResourceOwnerPasswordCredentialsGrantHandler) HandleTokenEndpointReques
 	access, err := c.Enigma.GenerateChallenge(requester.GetClient().GetHashedSecret())
 	if err != nil {
 		return errors.New(fosite.ErrServerError)
-	} else if err := c.Store.CreateAccessTokenSession(access.Signature, requester, &core.TokenSession{}); err != nil {
+	} else if err := c.Store.CreateAccessTokenSession(access.Signature, requester, &core.TokenSession{Extra: session}); err != nil {
 		return errors.New(fosite.ErrServerError)
 	}
 

--- a/handler/core/refresh/refresh.go
+++ b/handler/core/refresh/refresh.go
@@ -39,8 +39,7 @@ func (c *RefreshTokenGrantHandler) ValidateTokenEndpointRequest(_ context.Contex
 		return errors.New(fosite.ErrInvalidRequest)
 	}
 
-	var ts core.TokenSession
-	ar, err := c.Store.GetRefreshTokenSession(challenge.Signature, &ts)
+	ar, err := c.Store.GetRefreshTokenSession(challenge.Signature, &core.TokenSession{Extra: session})
 	if err == pkg.ErrNotFound {
 		return errors.New(fosite.ErrInvalidRequest)
 	} else if err != nil {
@@ -65,14 +64,14 @@ func (c *RefreshTokenGrantHandler) HandleTokenEndpointRequest(ctx context.Contex
 	access, err := c.Enigma.GenerateChallenge(requester.GetClient().GetHashedSecret())
 	if err != nil {
 		return errors.New(fosite.ErrServerError)
-	} else if err := c.Store.CreateAccessTokenSession(access.Signature, requester, &core.TokenSession{}); err != nil {
+	} else if err := c.Store.CreateAccessTokenSession(access.Signature, requester, &core.TokenSession{Extra: session}); err != nil {
 		return errors.New(fosite.ErrServerError)
 	}
 
 	refresh, err := c.Enigma.GenerateChallenge(requester.GetClient().GetHashedSecret())
 	if err != nil {
 		return errors.New(fosite.ErrServerError)
-	} else if err := c.Store.CreateRefreshTokenSession(refresh.Signature, requester, &core.TokenSession{}); err != nil {
+	} else if err := c.Store.CreateRefreshTokenSession(refresh.Signature, requester, &core.TokenSession{Extra: session}); err != nil {
 		return errors.New(fosite.ErrServerError)
 	}
 


### PR DESCRIPTION
When retrieving an auth code, you can optionally set the ```TokenSession.Extra``` data to store additional data like a user id that was stored when you created the authorization code. That session data should be available in ```CreateAccessTokenSession``` and ```CreateRefreshTokenSession```, but it ends up coming through nil.

This pull request ensures that session data passes through to the access token and refresh token so you can -- at the very least -- associate user ids with the access/refresh tokens.go in your storage implementation.