### PR TITLE
storage: fix storage implementation. Authorization should use AuthorizeRequester interface

### DIFF
--- a/handler/core/storage.go
+++ b/handler/core/storage.go
@@ -5,9 +5,9 @@ import (
 )
 
 type AuthorizeCodeStorage interface {
-	CreateAuthorizeCodeSession(code string, request fosite.Requester) (err error)
+	CreateAuthorizeCodeSession(code string, request fosite.AuthorizeRequester) (err error)
 
-	GetAuthorizeCodeSession(code string, session interface{}) (request fosite.Requester, err error)
+	GetAuthorizeCodeSession(code string, session interface{}) (request fosite.AuthorizeRequester, err error)
 
 	DeleteAuthorizeCodeSession(code string) (err error)
 }

--- a/internal/core_explicit_storage.go
+++ b/internal/core_explicit_storage.go
@@ -39,7 +39,7 @@ func (_mr *_MockAuthorizeCodeGrantStorageRecorder) CreateAccessTokenSession(arg0
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAccessTokenSession", arg0, arg1)
 }
 
-func (_m *MockAuthorizeCodeGrantStorage) CreateAuthorizeCodeSession(_param0 string, _param1 fosite.Requester) error {
+func (_m *MockAuthorizeCodeGrantStorage) CreateAuthorizeCodeSession(_param0 string, _param1 fosite.AuthorizeRequester) error {
 	ret := _m.ctrl.Call(_m, "CreateAuthorizeCodeSession", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -100,9 +100,9 @@ func (_mr *_MockAuthorizeCodeGrantStorageRecorder) GetAccessTokenSession(arg0, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccessTokenSession", arg0, arg1)
 }
 
-func (_m *MockAuthorizeCodeGrantStorage) GetAuthorizeCodeSession(_param0 string, _param1 interface{}) (fosite.Requester, error) {
+func (_m *MockAuthorizeCodeGrantStorage) GetAuthorizeCodeSession(_param0 string, _param1 interface{}) (fosite.AuthorizeRequester, error) {
 	ret := _m.ctrl.Call(_m, "GetAuthorizeCodeSession", _param0, _param1)
-	ret0, _ := ret[0].(fosite.Requester)
+	ret0, _ := ret[0].(fosite.AuthorizeRequester)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
The last commit for work on #20 made major API updates, but broke the authorize code implementation in the storage. Storage should use ```fosite.AuthorizeRequester``` interface in ```CreateAuthorizeCodeSession``` and ```GetAuthorizeCodeSession``` -- ```fosite.Requester``` is used. This PR updates the storage interface and related tests.

Signed-off-by: Cristian Graziano