### PR TITLE
fix jwt strategy interface mismatch

### DIFF
--- a/handler/core/strategy/jwt.go
+++ b/handler/core/strategy/jwt.go
@@ -39,7 +39,7 @@ func (h *RS256JWTStrategy) GenerateAccessToken(_ context.Context, requester fosi
 	return h.generate(requester)
 }
 
-func (h *RS256JWTStrategy) ValidateAccessToken(_ context.Context, _ fosite.Requester, token string) (signature string, err error) {
+func (h *RS256JWTStrategy) ValidateAccessToken(_ context.Context, _ fosite.Requester, token string) error {
 	return h.validate(token)
 }
 
@@ -47,7 +47,7 @@ func (h *RS256JWTStrategy) GenerateRefreshToken(_ context.Context, requester fos
 	return h.generate(requester)
 }
 
-func (h *RS256JWTStrategy) ValidateRefreshToken(_ context.Context, _ fosite.Requester, token string) (signature string, err error) {
+func (h *RS256JWTStrategy) ValidateRefreshToken(_ context.Context, _ fosite.Requester, token string) error {
 	return h.validate(token)
 }
 
@@ -55,22 +55,22 @@ func (h *RS256JWTStrategy) GenerateAuthorizeCode(_ context.Context, requester fo
 	return h.generate(requester)
 }
 
-func (h *RS256JWTStrategy) ValidateAuthorizeCode(_ context.Context, requester fosite.Requester, token string) (signature string, err error) {
+func (h *RS256JWTStrategy) ValidateAuthorizeCode(_ context.Context, requester fosite.Requester, token string) error {
 	return h.validate(token)
 }
 
-func (h *RS256JWTStrategy) validate(token string) (string, error) {
+func (h *RS256JWTStrategy) validate(token string) error {
 	t, err := h.RS256JWTStrategy.Decode(token)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	claims := jwt.JWTClaimsFromMap(t.Claims)
 	if claims.IsNotYetValid() || claims.IsExpired() {
-		return "", errors.New("Token claims did not validate")
+		return errors.New("Token claims did not validate")
 	}
 
-	return h.RS256JWTStrategy.GetSignature(token)
+	return nil
 }
 
 func (h *RS256JWTStrategy) generate(requester fosite.Requester) (string, string, error) {

--- a/handler/core/strategy/jwt_test.go
+++ b/handler/core/strategy/jwt_test.go
@@ -75,7 +75,8 @@ func TestAccessToken(t *testing.T) {
 		assert.Nil(t, err, "%s", err)
 		assert.Equal(t, strings.Split(token, ".")[2], signature)
 
-		validate, err := j.ValidateAccessToken(nil, &c.r, token)
+		validate := j.signature(token)
+		err = j.ValidateAccessToken(nil, &c.r, token)
 		if c.pass {
 			assert.Nil(t, err, "%s", err)
 			assert.Equal(t, signature, validate)
@@ -90,7 +91,8 @@ func TestRefreshToken(t *testing.T) {
 	assert.Nil(t, err, "%s", err)
 	assert.Equal(t, strings.Split(token, ".")[2], signature)
 
-	validate, err := j.ValidateRefreshToken(nil, &jwtValidCase, token)
+	validate := j.signature(token)
+	err = j.ValidateRefreshToken(nil, &jwtValidCase, token)
 	assert.Nil(t, err, "%s", err)
 	assert.Equal(t, signature, validate)
 }
@@ -113,7 +115,8 @@ func TestGenerateAuthorizeCode(t *testing.T) {
 		assert.Nil(t, err, "%s", err)
 		assert.Equal(t, strings.Split(token, ".")[2], signature)
 
-		validate, err := j.ValidateAuthorizeCode(nil, &c.r, token)
+		validate := j.signature(token)
+		err = j.ValidateAuthorizeCode(nil, &c.r, token)
 		if c.pass {
 			assert.Nil(t, err, "%s", err)
 			assert.Equal(t, signature, validate)


### PR DESCRIPTION
Validate token function only return error by [interface definition](https://github.com/ory-am/fosite/blob/dfb047d/handler/core/strategy.go), but in jwt strategy return both signature and error.