### PR TITLE
Extract username and password from header and fallback to body

### DIFF
--- a/handler/core/owner/owner.go
+++ b/handler/core/owner/owner.go
@@ -28,8 +28,12 @@ func (c *ResourceOwnerPasswordCredentialsGrantHandler) HandleTokenEndpointReques
 		return errors.Wrap(fosite.ErrInvalidGrant, "")
 	}
 
-	username := req.PostForm.Get("username")
-	password := req.PostForm.Get("password")
+	username, password, ok := req.BasicAuth()
+	if !ok {
+		username = req.PostForm.Get("username")
+		password = req.PostForm.Get("password")
+	}
+
 	if username == "" || password == "" {
 		return errors.Wrap(fosite.ErrInvalidRequest, "")
 	} else if err := c.ResourceOwnerPasswordCredentialsGrantStorage.Authenticate(ctx, username, password); errors.Cause(err) == fosite.ErrNotFound {


### PR DESCRIPTION
Hi, thanks for this amazing library!

I started to use it to implement an OAuth2 layer for my small API framework: https://github.com/256dpi/fire

While working on the Resource Owner Credential Flow I realized that the credentials have to be submitted in the Header and the Body of the Request. But this behavior contradicts with the following statement in the docs:

> Including the client credentials in the request-body using the two parameters is NOT RECOMMENDED and SHOULD be limited to clients unable to directly utilize the HTTP Basic authentication scheme (or other password-based HTTP authentication schemes).  The parameters can only be transmitted in the request-body and MUST NOT be included in the request URI.

This PR tries to extract the username and password first from the header and then falls back to the body.