### PR TITLE
oauth2: implicit handlers do not require tls over https

### DIFF
--- a/authorize_helper.go
+++ b/authorize_helper.go
@@ -93,11 +93,11 @@ func IsValidRedirectURI(redirectURI *url.URL) bool {
 		return false
 	}
 
-	if redirectURI.Scheme != "https" && !isLocalhost(redirectURI) {
-		return false
-	}
-
 	return true
+}
+
+func IsRedirectURISecure(redirectURI *url.URL) bool {
+	return !(redirectURI.Scheme != "https" && !isLocalhost(redirectURI))
 }
 
 func isLocalhost(redirectURI *url.URL) bool {

--- a/handler/core/explicit/explicit_auth.go
+++ b/handler/core/explicit/explicit_auth.go
@@ -41,6 +41,10 @@ func (c *AuthorizeExplicitGrantTypeHandler) HandleAuthorizeEndpointRequest(ctx c
 		return errors.Wrap(ErrInvalidGrant, "")
 	}
 
+	if !IsRedirectURISecure(ar.GetRedirectURI()) {
+		return errors.Wrap(ErrInvalidRequest, "")
+	}
+
 	return c.IssueAuthorizeCode(ctx, req, ar, resp)
 }
 

--- a/handler/core/explicit/explicit_auth_test.go
+++ b/handler/core/explicit/explicit_auth_test.go
@@ -46,10 +46,18 @@ func TestHandleAuthorizeEndpointRequest(t *testing.T) {
 			},
 		},
 		{
-			description: "should fail because authorize code generation failed",
+			description: "should fail because redirect uri is not https",
 			setup: func() {
 				areq.ResponseTypes = fosite.Arguments{"code"}
 				areq.Client = &fosite.DefaultClient{ResponseTypes: fosite.Arguments{"code"}}
+				areq.RedirectURI, _ = url.Parse("http://asdf.de/cb")
+			},
+			expectErr: fosite.ErrInvalidRequest,
+		},
+		{
+			description: "should fail because authorize code generation failed",
+			setup: func() {
+				areq.RedirectURI, _ = url.Parse("https://foobar.com/cb")
 				chgen.EXPECT().GenerateAuthorizeCode(nil, areq).Return("", "", errors.New(""))
 			},
 			expectErr: fosite.ErrServerError,

--- a/handler/core/implicit/implicit.go
+++ b/handler/core/implicit/implicit.go
@@ -39,6 +39,9 @@ func (c *AuthorizeImplicitGrantTypeHandler) HandleAuthorizeEndpointRequest(ctx c
 		return errors.Wrap(ErrInvalidGrant, "")
 	}
 
+	// there is no need to check for https, because implicit flow does not require https
+	// https://tools.ietf.org/html/rfc6819#section-4.4.2
+
 	return c.IssueImplicitAccessToken(ctx, req, ar, resp)
 }
 

--- a/handler/oidc/explicit/explicit_auth.go
+++ b/handler/oidc/explicit/explicit_auth.go
@@ -33,5 +33,7 @@ func (c *OpenIDConnectExplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 		return errors.Wrap(ErrServerError, err.Error())
 	}
 
+	// there is no need to check for https, because it has already been checked by core.explicit
+
 	return nil
 }

--- a/handler/oidc/hybrid/hybrid.go
+++ b/handler/oidc/hybrid/hybrid.go
@@ -91,6 +91,9 @@ func (c *OpenIDConnectHybridHandler) HandleAuthorizeEndpointRequest(ctx context.
 		return errors.Wrap(err, err.Error())
 	}
 
+	// there is no need to check for https, because implicit flow does not require https
+	// https://tools.ietf.org/html/rfc6819#section-4.4.2
+
 	ar.SetResponseTypeHandled("id_token")
 	return nil
 }

--- a/handler/oidc/implicit/implicit.go
+++ b/handler/oidc/implicit/implicit.go
@@ -58,6 +58,9 @@ func (c *OpenIDConnectImplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 		return errors.Wrap(err, err.Error())
 	}
 
+	// there is no need to check for https, because implicit flow does not require https
+	// https://tools.ietf.org/html/rfc6819#section-4.4.2
+
 	ar.SetResponseTypeHandled("id_token")
 	return nil
 }


### PR DESCRIPTION
closes #60