### PR TITLE
Updated: jwt-go is now v3.0.0.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,25 +1,12 @@
-hash: bfdddfe32cacf648c65b3dd8350e6c748c3ab84e46b47ea4548e0c20fb068034
-updated: 2016-08-09T09:17:29.732545671+02:00
+hash: 0ac686d5fd98f966adf0df5a617514913bdfe9f3c081919434d29395ded25c2f
+updated: 2016-08-22T11:10:29.823423512+02:00
 imports:
-- name: camlistore.org
-  version: 41516af23d58b64efe7712e8be2d3f9fd94fb693
-  subpackages:
-  - pkg/googlestorage
-  - pkg/blob
-  - pkg/constants
-- name: cloud.google.com/go
-  version: 3261f00d16e92932f49a39672dfd540896ed30d0
-  subpackages:
-  - compute/metadata
-  - internal
 - name: github.com/asaskevich/govalidator
   version: 7664702784775e51966f0885f5cd27435916517b
 - name: github.com/dgrijalva/jwt-go
-  version: 268038b363c7a8d7306b8e35bf77a1fde4b0c402
+  version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
 - name: github.com/go-errors/errors
   version: a41850380601eeb43f4350f7d17c6bbd8944aaf8
-- name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/mock
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
@@ -28,23 +15,6 @@ imports:
   version: c3cefd437628a0b7d31b34fe44b3a7a540e98527
   subpackages:
   - proto
-  - proto/testdata
-  - ptypes/any
-  - protoc-gen-go/descriptor
-  - ptypes/duration
-  - ptypes/empty
-  - ptypes/wrappers
-  - ptypes/timestamp
-  - ptypes/struct
-- name: github.com/googleapis/gax-go
-  version: 8b0741b94759890156bc4a00cedd6e4f7cf744de
-- name: github.com/googleapis/proto-client-go
-  version: e5790fe2658ab48a2a8f8bf5247be730d7f844f2
-  subpackages:
-  - logging/v2
-  - api
-  - logging/type_
-  - rpc
 - name: github.com/gorilla/context
   version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/gorilla/mux
@@ -55,6 +25,8 @@ imports:
   version: ec27669d960a245738b87ffa688dac28fa288c33
 - name: github.com/ory-am/common
   version: d93c852f2d09c219fd058756caf67bbdf8cf4be4
+  subpackages:
+  - pkg
 - name: github.com/parnurzeal/gorequest
   version: b64673b971a1742b8ba91f228f1c029632d4b686
 - name: github.com/pborman/uuid
@@ -63,127 +35,46 @@ imports:
   version: 01fa4104b9c248c8945d14d9f128454d5b28d595
 - name: github.com/Sirupsen/logrus
   version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
-- name: go4.org
-  version: 401618586120d672bfd8ddf033bafd1c96c31241
-  subpackages:
-  - syncutil/singleflight
-  - readerutil
 - name: golang.org/x/crypto
   version: e0d166c33c321d0ff863f459a5882096e334f508
   subpackages:
   - bcrypt
   - blowfish
-  - ssh/terminal
 - name: golang.org/x/net
   version: 075e191f18186a8ff2becaf64478e30f4545cdad
   subpackages:
   - context
   - publicsuffix
-  - http2
-  - trace
-  - http2/hpack
-  - lex/httplex
-  - internal/timeseries
 - name: golang.org/x/oauth2
   version: 04e1573abc896e70388bd387a69753c378d46466
   subpackages:
   - clientcredentials
   - internal
-  - jws
-  - jwt
 - name: golang.org/x/sys
   version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
   subpackages:
   - unix
-- name: google.golang.org/api
-  version: 518eda9a0920a55ffe7190db96fe8ed85a62e376
-  subpackages:
-  - compute/v1
-  - storage/v1
-  - gensupport
-  - googleapi
-  - googleapi/internal/uritemplates
-  - option
-  - transport
-  - internal
-  - bigquery/v2
-  - container/v1
-  - logging/v1beta3
-  - pubsub/v1
-  - cloudtrace/v1
 - name: google.golang.org/appengine
   version: b4728023490a62e70ba739ff62aa65ffcca84210
   subpackages:
-  - urlfetch
   - internal
-  - internal/urlfetch
-  - internal/app_identity
-  - internal/modules
-  - user
-  - datastore
   - internal/base
-  - internal/blobstore
-  - internal/capability
-  - log
-  - internal/channel
   - internal/datastore
-  - taskqueue
-  - internal/image
   - internal/log
   - internal/remote_api
-- name: google.golang.org/cloud
-  version: c14fbfa4d259bf20a9a236a19c03a8b05f12b444
-  subpackages:
-  - compute/metadata
-  - internal
-  - bigtable/internal/option
-  - bigtable/internal/cbtrc
-  - bigtable/internal/stat
-  - logging
-  - pubsub
-  - storage
-- name: google.golang.org/genproto
-  version: 8fd005e65f7937d0cb1a83436c5c5bd3b9df0e43
-  subpackages:
-  - googleapis/bigtable/admin/v2
-  - googleapis/bigtable/v2
-  - googleapis/rpc
-  - googleapis/datastore/v1beta3
-  - googleapis/type
-  - googleapis/api/serviceconfig
-  - googleapis/longrunning
-  - googleapis/rpc/status
-  - googleapis/api/label
-  - googleapis/api/metric
-  - googleapis/api/monitoredres
-  - protobuf
-- name: google.golang.org/grpc
-  version: 35896af9ad39c1fb1b1cd925fe3621be361e3d81
-  subpackages:
-  - codes
-  - credentials
-  - grpclog
-  - internal
-  - metadata
-  - naming
-  - transport
-  - benchmark/grpc_testing
-  - benchmark/stats
-  - examples/helloworld/helloworld
-  - examples/route_guide/routeguide
-  - health/grpc_health_v1
-  - interop/grpc_testing
-  - reflection/grpc_reflection_v1alpha
-  - stress/grpc_testing
-- name: gopkg.in/airbrake/gobrake.v2
-  version: 31c8ff1fb8b79a6947e6565e9a6df535f98a6b94
-- name: gopkg.in/gemnasium/logrus-airbrake-hook.v2
-  version: 31e6fd4bd5a98d8ee7673d24bc54ec73c31810dd
+  - internal/urlfetch
+  - urlfetch
 testImports:
 - name: github.com/davecgh/go-spew
   version: 2df174808ee097f90d259e432cc04442cf60be21
   subpackages:
   - spew
+- name: github.com/elazarl/goproxy
+  version: 0a5b8bdb09049ae4ae68e75437ded0b7a2e324e3
+- name: github.com/onsi/ginkgo
+  version: 462326b1628e124b23f42e87a8f2750e3c4e2d24
+- name: github.com/onsi/gomega
+  version: a78ae492d53aad5a7a232d0d0462c14c400e3ee7
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -193,3 +84,7 @@ testImports:
   subpackages:
   - assert
   - require
+- name: gopkg.in/airbrake/gobrake.v2
+  version: 31c8ff1fb8b79a6947e6565e9a6df535f98a6b94
+- name: gopkg.in/gemnasium/logrus-airbrake-hook.v2
+  version: 31e6fd4bd5a98d8ee7673d24bc54ec73c31810dd

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/asaskevich/govalidator
   version: ~4.0.0
 - package: github.com/dgrijalva/jwt-go
-  version: ~2.7.0
+  version: ~3.0.0
 - package: github.com/golang/mock
   subpackages:
   - gomock
@@ -38,3 +38,13 @@ testImport:
   subpackages:
   - assert
   - require
+- package: gopkg.in/gemnasium/logrus-airbrake-hook.v2
+  version: ^2.0.0
+- package: gopkg.in/airbrake/gobrake.v2
+  version: ^2.0.6
+- package: github.com/onsi/ginkgo
+  version: ^1.2.0
+- package: github.com/elazarl/goproxy
+  version: ^1.0.0
+- package: github.com/onsi/gomega
+  version: ^1.0.0

--- a/handler/oauth2/strategy_jwt.go
+++ b/handler/oauth2/strategy_jwt.go
@@ -65,8 +65,8 @@ func (h *RS256JWTStrategy) validate(token string) error {
 		return err
 	}
 
-	claims := jwt.JWTClaimsFromMap(t.Claims)
-	if claims.IsNotYetValid() || claims.IsExpired() {
+	// validate the token
+	if err = t.Claims.Valid(); err != nil {
 		return errors.New("Token claims did not validate")
 	}
 
@@ -79,6 +79,6 @@ func (h *RS256JWTStrategy) generate(requester fosite.Requester) (string, string,
 	} else if jwtSession.GetJWTClaims() == nil {
 		return "", "", errors.New("GetTokenClaims() must not be nil")
 	} else {
-		return h.RS256JWTStrategy.Generate(jwtSession.GetJWTClaims(), jwtSession.GetJWTHeader())
+		return h.RS256JWTStrategy.Generate(jwtSession.GetJWTClaims().ToMapClaims(), jwtSession.GetJWTHeader())
 	}
 }

--- a/handler/openid/strategy_jwt.go
+++ b/handler/openid/strategy_jwt.go
@@ -92,6 +92,6 @@ func (h DefaultStrategy) GenerateIDToken(_ context.Context, _ *http.Request, req
 	claims.Audience = requester.GetClient().GetID()
 	claims.IssuedAt = time.Now()
 
-	token, _, err = h.RS256JWTStrategy.Generate(claims, sess.IDTokenHeaders())
+	token, _, err = h.RS256JWTStrategy.Generate(claims.ToMapClaims(), sess.IDTokenHeaders())
 	return token, err
 }

--- a/token/jwt/claims.go
+++ b/token/jwt/claims.go
@@ -1,15 +1,15 @@
 package jwt
 
-import (
-	"time"
-)
+import "time"
 
+// Mapper is the interface used internally to map key-value pairs
 type Mapper interface {
 	ToMap() map[string]interface{}
 	Add(key string, value interface{})
 	Get(key string) interface{}
 }
 
+// ToString will return a string representation of a map
 func ToString(i interface{}) string {
 	if i == nil {
 		return ""
@@ -22,6 +22,7 @@ func ToString(i interface{}) string {
 	return ""
 }
 
+// ToTime will try to convert a given input to a time.Time structure
 func ToTime(i interface{}) time.Time {
 	if i == nil {
 		return time.Time{}
@@ -36,6 +37,7 @@ func ToTime(i interface{}) time.Time {
 	return time.Time{}
 }
 
+// Filter will filter out elemets based on keys in a given input map na key-slice
 func Filter(elements map[string]interface{}, keys ...string) map[string]interface{} {
 	var keyIdx = make(map[string]bool)
 	var result = make(map[string]interface{})
@@ -53,6 +55,7 @@ func Filter(elements map[string]interface{}, keys ...string) map[string]interfac
 	return result
 }
 
+// Copy will copy all elements in a map and return a new representational map
 func Copy(elements map[string]interface{}) (result map[string]interface{}) {
 	result = make(map[string]interface{}, len(elements))
 	for k, v := range elements {

--- a/token/jwt/claims_id_token.go
+++ b/token/jwt/claims_id_token.go
@@ -1,7 +1,12 @@
 package jwt
 
-import "time"
+import (
+	"time"
 
+	"github.com/dgrijalva/jwt-go"
+)
+
+// IDTokenClaims represent the claims used in open id connect requests
 type IDTokenClaims struct {
 	Issuer          string
 	Subject         string
@@ -15,6 +20,7 @@ type IDTokenClaims struct {
 	Extra           map[string]interface{}
 }
 
+// ToMap will transform the headers to a map structure
 func (c *IDTokenClaims) ToMap() map[string]interface{} {
 	var ret = Copy(c.Extra)
 	ret["sub"] = c.Subject
@@ -33,12 +39,14 @@ func (c *IDTokenClaims) ToMap() map[string]interface{} {
 	if !c.AuthTime.IsZero() {
 		ret["auth_time"] = c.AuthTime.Unix()
 	}
-	ret["iat"] = c.IssuedAt.Unix()
-	ret["exp"] = c.ExpiresAt.Unix()
+
+	ret["iat"] = float64(c.IssuedAt.Unix())
+	ret["exp"] = float64(c.ExpiresAt.Unix())
 	return ret
 
 }
 
+// Add will add a key-value pair to the extra field
 func (c *IDTokenClaims) Add(key string, value interface{}) {
 	if c.Extra == nil {
 		c.Extra = make(map[string]interface{})
@@ -46,6 +54,12 @@ func (c *IDTokenClaims) Add(key string, value interface{}) {
 	c.Extra[key] = value
 }
 
+// Get will get a value from the extra field based on a given key
 func (c *IDTokenClaims) Get(key string) interface{} {
 	return c.ToMap()[key]
+}
+
+// ToMapClaims will return a jwt-go MapClaims representaion
+func (c IDTokenClaims) ToMapClaims() jwt.MapClaims {
+	return c.ToMap()
 }

--- a/token/jwt/claims_id_token_test.go
+++ b/token/jwt/claims_id_token_test.go
@@ -23,25 +23,21 @@ var idTokenClaims = &IDTokenClaims{
 	},
 }
 
-func TestIDTokenClaimsToMapSetsID(t *testing.T) {
-	assert.NotEmpty(t, (&JWTClaims{}).ToMap()["jti"])
-}
-
 func TestIDTokenAssert(t *testing.T) {
-	assert.False(t, (&JWTClaims{ExpiresAt: time.Now().Add(time.Hour)}).IsExpired())
-	assert.True(t, (&JWTClaims{ExpiresAt: time.Now().Add(-time.Hour)}).IsExpired())
-	assert.True(t, (&JWTClaims{NotBefore: time.Now().Add(time.Hour)}).IsNotYetValid())
-	assert.False(t, (&JWTClaims{NotBefore: time.Now().Add(-time.Hour)}).IsNotYetValid())
+	assert.Nil(t, (&IDTokenClaims{ExpiresAt: time.Now().Add(time.Hour)}).
+		ToMapClaims().Valid())
+	assert.NotNil(t, (&IDTokenClaims{ExpiresAt: time.Now().Add(-time.Hour)}).
+		ToMapClaims().Valid())
 }
 
 func TestIDTokenClaimsToMap(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{
 		"sub":       idTokenClaims.Subject,
-		"iat":       idTokenClaims.IssuedAt.Unix(),
+		"iat":       float64(idTokenClaims.IssuedAt.Unix()),
 		"iss":       idTokenClaims.Issuer,
 		"aud":       idTokenClaims.Audience,
 		"nonce":     idTokenClaims.Nonce,
-		"exp":       idTokenClaims.ExpiresAt.Unix(),
+		"exp":       float64(idTokenClaims.ExpiresAt.Unix()),
 		"foo":       idTokenClaims.Extra["foo"],
 		"baz":       idTokenClaims.Extra["baz"],
 		"at_hash":   idTokenClaims.AccessTokenHash,

--- a/token/jwt/claims_jwt_test.go
+++ b/token/jwt/claims_jwt_test.go
@@ -31,26 +31,27 @@ func TestClaimsToMapSetsID(t *testing.T) {
 	assert.NotEmpty(t, (&JWTClaims{}).ToMap()["jti"])
 }
 
-func TestClaimsToFromMap(t *testing.T) {
-	fromMap := JWTClaimsFromMap(jwtClaims.ToMap())
-	assert.Equal(t, jwtClaims, fromMap)
-}
-
 func TestAssert(t *testing.T) {
-	assert.False(t, (&JWTClaims{ExpiresAt: time.Now().Add(time.Hour)}).IsExpired())
-	assert.True(t, (&JWTClaims{ExpiresAt: time.Now().Add(-time.Hour)}).IsExpired())
-	assert.True(t, (&JWTClaims{NotBefore: time.Now().Add(time.Hour)}).IsNotYetValid())
-	assert.False(t, (&JWTClaims{NotBefore: time.Now().Add(-time.Hour)}).IsNotYetValid())
+	assert.Nil(t, (&JWTClaims{ExpiresAt: time.Now().Add(time.Hour)}).
+		ToMapClaims().Valid())
+	assert.NotNil(t, (&JWTClaims{ExpiresAt: time.Now().Add(-2 * time.Hour)}).
+		ToMapClaims().Valid())
+	assert.NotNil(t, (&JWTClaims{NotBefore: time.Now().Add(time.Hour)}).
+		ToMapClaims().Valid())
+	assert.NotNil(t, (&JWTClaims{NotBefore: time.Now().Add(-time.Hour)}).
+		ToMapClaims().Valid())
+	assert.Nil(t, (&JWTClaims{ExpiresAt: time.Now().Add(time.Hour),
+		NotBefore: time.Now().Add(-time.Hour)}).ToMapClaims().Valid())
 }
 
 func TestClaimsToMap(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{
 		"sub": jwtClaims.Subject,
-		"iat": jwtClaims.IssuedAt.Unix(),
+		"iat": float64(jwtClaims.IssuedAt.Unix()),
 		"iss": jwtClaims.Issuer,
-		"nbf": jwtClaims.NotBefore.Unix(),
+		"nbf": float64(jwtClaims.NotBefore.Unix()),
 		"aud": jwtClaims.Audience,
-		"exp": jwtClaims.ExpiresAt.Unix(),
+		"exp": float64(jwtClaims.ExpiresAt.Unix()),
 		"jti": jwtClaims.JTI,
 		"foo": jwtClaims.Extra["foo"],
 		"baz": jwtClaims.Extra["baz"],

--- a/token/jwt/header.go
+++ b/token/jwt/header.go
@@ -1,10 +1,13 @@
 package jwt
 
-// HeaderContext is the context for a jwt header.
+import "github.com/dgrijalva/jwt-go"
+
+// Headers is the jwt headers
 type Headers struct {
 	Extra map[string]interface{}
 }
 
+// ToMap will transform the headers to a map structure
 func (h *Headers) ToMap() map[string]interface{} {
 	var filter = map[string]bool{"alg": true, "typ": true}
 	var extra = map[string]interface{}{}
@@ -19,6 +22,7 @@ func (h *Headers) ToMap() map[string]interface{} {
 	return extra
 }
 
+// Add will add a key-value pair to the extra field
 func (h *Headers) Add(key string, value interface{}) {
 	if h.Extra == nil {
 		h.Extra = make(map[string]interface{})
@@ -26,6 +30,12 @@ func (h *Headers) Add(key string, value interface{}) {
 	h.Extra[key] = value
 }
 
+// Get will get a value from the extra field based on a given key
 func (h *Headers) Get(key string) interface{} {
 	return h.Extra[key]
+}
+
+// ToMapClaims will return a jwt-go MapClaims representaion
+func (h Headers) ToMapClaims() jwt.MapClaims {
+	return h.ToMap()
 }

--- a/token/jwt/jwt_test.go
+++ b/token/jwt/jwt_test.go
@@ -63,7 +63,7 @@ func TestGenerateJWT(t *testing.T) {
 		PrivateKey: internal.MustRSAKey(),
 	}
 
-	token, sig, err := j.Generate(claims, header)
+	token, sig, err := j.Generate(claims.ToMapClaims(), header)
 	require.Nil(t, err, "%s", err)
 	require.NotNil(t, token)
 
@@ -82,27 +82,28 @@ func TestGenerateJWT(t *testing.T) {
 	j.PrivateKey = internal.MustRSAKey()
 
 	// Lets validate the exp claim
-	claims = &JWTClaims{}
-
-	token, sig, err = j.Generate(claims, header)
+	claims = &JWTClaims{
+		ExpiresAt: time.Now().Add(-time.Hour),
+	}
+	token, sig, err = j.Generate(claims.ToMapClaims(), header)
 	require.Nil(t, err, "%s", err)
 	require.NotNil(t, token)
-	t.Logf("%s.%s", token, sig)
+	//t.Logf("%s.%s", token, sig)
 
 	sig, err = j.Validate(token)
 	require.NotNil(t, err, "%s", err)
 
 	// Lets validate the nbf claim
-	claims = &JWTClaims{}
-
-	token, sig, err = j.Generate(claims, header)
+	claims = &JWTClaims{
+		NotBefore: time.Now().Add(time.Hour),
+	}
+	token, sig, err = j.Generate(claims.ToMapClaims(), header)
 	require.Nil(t, err, "%s", err)
 	require.NotNil(t, token)
-	t.Logf("%s.%s", token, sig)
-
+	//t.Logf("%s.%s", token, sig)
 	sig, err = j.Validate(token)
 	require.NotNil(t, err, "%s", err)
-
+	require.Empty(t, sig, "%s", err)
 }
 
 func TestValidateSignatureRejectsJWT(t *testing.T) {


### PR DESCRIPTION
This PR is in direct response to #76.

NOTE:
No direct breaking API changes should have been introduced in this pull request, as long as no one explicitly uses the raw values of "iat", "exp" and "nbf" claims (was int, is now float). This is due to the fact that jwt-go needs float64 types when validating the claims. I will create a new PR to jwt-go as well that is going to allow int64 values to be parsed. Hopefully it will get merged fast. If that's the case, after a minor upgrade to fosite removing the float64 casts, nothing API-wise will have changed since before the upgrade to jwt-go 3.0.0. 

// Alex