### PR TITLE
authorize: scopes should be separated by %20 and not +, to ensure jav…

### DIFF
--- a/authorize_write.go
+++ b/authorize_write.go
@@ -2,6 +2,12 @@ package fosite
 
 import (
 	"net/http"
+	"regexp"
+)
+
+var (
+	// scopeMatch = regexp.MustCompile("scope=[^\\&]+.*$")
+	plusMatch = regexp.MustCompile("\\+")
 )
 
 func (c *Fosite) WriteAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequester, resp AuthorizeResponder) {
@@ -25,11 +31,14 @@ func (c *Fosite) WriteAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequ
 	// Implicit grants
 	redir.Fragment = resp.GetFragment().Encode()
 
+	u := redir.String()
+	u = plusMatch.ReplaceAllString(u, "%20")
+
 	// https://tools.ietf.org/html/rfc6749#section-4.1.1
 	// When a decision is established, the authorization server directs the
 	// user-agent to the provided client redirection URI using an HTTP
 	// redirection response, or by other means available to it via the
 	// user-agent.
-	wh.Set("Location", redir.String())
+	wh.Set("Location", u)
 	rw.WriteHeader(http.StatusFound)
 }

--- a/authorize_write_test.go
+++ b/authorize_write_test.go
@@ -79,9 +79,9 @@ func TestWriteAuthorizeResponse(t *testing.T) {
 			setup: func() {
 				redir, _ := url.Parse("https://foobar.com/?foo=bar")
 				ar.EXPECT().GetRedirectURI().Return(redir)
-				resp.EXPECT().GetFragment().Return(url.Values{"bar": {"baz"}})
+				resp.EXPECT().GetFragment().Return(url.Values{"bar": {"baz"}, "scope": {"a b"}})
 				resp.EXPECT().GetHeader().Return(http.Header{"X-Bar": {"baz"}})
-				resp.EXPECT().GetQuery().Return(url.Values{"bar": {"baz"}})
+				resp.EXPECT().GetQuery().Return(url.Values{"bar": {"b+az"}, "scope": {"a b"}})
 
 				rw.EXPECT().Header().Return(header)
 				rw.EXPECT().WriteHeader(http.StatusFound)
@@ -89,7 +89,7 @@ func TestWriteAuthorizeResponse(t *testing.T) {
 			expect: func() {
 				assert.Equal(t, http.Header{
 					"X-Bar":    {"baz"},
-					"Location": {"https://foobar.com/?bar=baz&foo=bar#bar=baz"},
+					"Location": {"https://foobar.com/?bar=b%2Baz&foo=bar&scope=a%20b#bar=baz&scope=a%20b"},
 				}, header)
 			},
 		},


### PR DESCRIPTION
…ascript compatibility - closes #101