### PR TITLE
oauth2: added refresh token generation for password grant type

### DIFF
--- a/compose/compose_oauth2.go
+++ b/compose/compose_oauth2.go
@@ -108,7 +108,8 @@ func OAuth2ResourceOwnerPasswordCredentialsFactory(config *Config, storage inter
 				AccessTokenStorage:  storage.(oauth2.AccessTokenStorage),
 				AccessTokenLifespan: config.GetAccessTokenLifespan(),
 			},
-			ScopeStrategy: fosite.HierarchicScopeStrategy,
+			RefreshTokenStrategy: strategy.(oauth2.RefreshTokenStrategy),
+			ScopeStrategy:        fosite.HierarchicScopeStrategy,
 		},
 		CoreValidator: &oauth2.CoreValidator{
 			CoreStrategy:  strategy.(oauth2.CoreStrategy),

--- a/fosite-example/main.go
+++ b/fosite-example/main.go
@@ -131,6 +131,11 @@ func tokenEndpoint(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Grant requested scopes
+	for _, scope := range accessRequest.GetRequestedScopes() {
+		accessRequest.GrantScope(scope)
+	}
+
 	// Next we create a response for the access request. Again, we iterate through the TokenEndpointHandlers
 	// and aggregate the result in response.
 	response, err := oauth2.NewAccessResponse(ctx, req, accessRequest)

--- a/handler/oauth2/flow_resource_owner_storage.go
+++ b/handler/oauth2/flow_resource_owner_storage.go
@@ -7,4 +7,5 @@ import (
 type ResourceOwnerPasswordCredentialsGrantStorage interface {
 	Authenticate(ctx context.Context, name string, secret string) error
 	AccessTokenStorage
+	RefreshTokenStorage
 }

--- a/internal/oauth2_owner_storage.go
+++ b/internal/oauth2_owner_storage.go
@@ -50,6 +50,16 @@ func (_mr *_MockResourceOwnerPasswordCredentialsGrantStorageRecorder) CreateAcce
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAccessTokenSession", arg0, arg1, arg2)
 }
 
+func (_m *MockResourceOwnerPasswordCredentialsGrantStorage) CreateRefreshTokenSession(_param0 context.Context, _param1 string, _param2 fosite.Requester) error {
+	ret := _m.ctrl.Call(_m, "CreateRefreshTokenSession", _param0, _param1, _param2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockResourceOwnerPasswordCredentialsGrantStorageRecorder) CreateRefreshTokenSession(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRefreshTokenSession", arg0, arg1, arg2)
+}
+
 func (_m *MockResourceOwnerPasswordCredentialsGrantStorage) DeleteAccessTokenSession(_param0 context.Context, _param1 string) error {
 	ret := _m.ctrl.Call(_m, "DeleteAccessTokenSession", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -58,6 +68,16 @@ func (_m *MockResourceOwnerPasswordCredentialsGrantStorage) DeleteAccessTokenSes
 
 func (_mr *_MockResourceOwnerPasswordCredentialsGrantStorageRecorder) DeleteAccessTokenSession(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccessTokenSession", arg0, arg1)
+}
+
+func (_m *MockResourceOwnerPasswordCredentialsGrantStorage) DeleteRefreshTokenSession(_param0 context.Context, _param1 string) error {
+	ret := _m.ctrl.Call(_m, "DeleteRefreshTokenSession", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockResourceOwnerPasswordCredentialsGrantStorageRecorder) DeleteRefreshTokenSession(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRefreshTokenSession", arg0, arg1)
 }
 
 func (_m *MockResourceOwnerPasswordCredentialsGrantStorage) GetAccessTokenSession(_param0 context.Context, _param1 string, _param2 interface{}) (fosite.Requester, error) {
@@ -69,4 +89,15 @@ func (_m *MockResourceOwnerPasswordCredentialsGrantStorage) GetAccessTokenSessio
 
 func (_mr *_MockResourceOwnerPasswordCredentialsGrantStorageRecorder) GetAccessTokenSession(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccessTokenSession", arg0, arg1, arg2)
+}
+
+func (_m *MockResourceOwnerPasswordCredentialsGrantStorage) GetRefreshTokenSession(_param0 context.Context, _param1 string, _param2 interface{}) (fosite.Requester, error) {
+	ret := _m.ctrl.Call(_m, "GetRefreshTokenSession", _param0, _param1, _param2)
+	ret0, _ := ret[0].(fosite.Requester)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockResourceOwnerPasswordCredentialsGrantStorageRecorder) GetRefreshTokenSession(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRefreshTokenSession", arg0, arg1, arg2)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -21,5 +21,35 @@ func TestRequest(t *testing.T) {
 
 	assert.Equal(t, r.RequestedAt, r.GetRequestedAt())
 	assert.Equal(t, r.Client, r.GetClient())
+	assert.Equal(t, r.GrantedScopes, r.GetGrantedScopes())
+	assert.Equal(t, r.Scopes, r.GetRequestedScopes())
+	assert.Equal(t, r.Form, r.GetRequestForm())
+	assert.Equal(t, r.Session, r.GetSession())
+}
 
+func TestMergeRequest(t *testing.T) {
+	a := &Request{
+		RequestedAt:   time.Now(),
+		Client:        &DefaultClient{ID:"123"},
+		Scopes:        Arguments{"asdff"},
+		GrantedScopes: []string{"asdf"},
+		Form:          url.Values{"foo": []string{"fasdf"}},
+		Session:       54321,
+	}
+	b := &Request{
+		RequestedAt:   time.Now(),
+		Client:        &DefaultClient{},
+		Scopes:        Arguments{},
+		GrantedScopes: []string{},
+		Form:          url.Values{},
+		Session:       12345,
+	}
+
+	b.Merge(a)
+	assert.EqualValues(t, a.RequestedAt, b.RequestedAt)
+	assert.EqualValues(t, a.Client, b.Client)
+	assert.EqualValues(t, a.Scopes, b.Scopes)
+	assert.EqualValues(t, a.GrantedScopes, b.GrantedScopes)
+	assert.EqualValues(t, a.Form, b.Form)
+	assert.EqualValues(t, a.Session, b.Session)
 }


### PR DESCRIPTION
I'm currently porting over some old authentication services with fosite and have ran into the issue specified here: https://github.com/ory-am/fosite/issues/78

Where internal clients will make use of the password grant type along with the access / refresh tokens.

There was a comment suggesting that this particular feature be added as a separate PR than the issue raised; and since it's been around a month with no updates I decided to give it a go.

Please let me know if anything doesn't meet the RFC or needs changes.