### PR TITLE
handler/oauth2: set JWT ExpiresAt claim per TokenType from the session

### DIFF
--- a/handler/oauth2/strategy_jwt_test.go
+++ b/handler/oauth2/strategy_jwt_test.go
@@ -17,66 +17,80 @@ var j = &RS256JWTStrategy{
 	},
 }
 
-var jwtValidCase = fosite.Request{
-	Client: &fosite.DefaultClient{
-		Secret: []byte("foobarfoobarfoobarfoobar"),
-	},
-	Session: &JWTSession{
-		JWTClaims: &jwt.JWTClaims{
-			Issuer:    "fosite",
-			Subject:   "peter",
-			Audience:  "group0",
-			ExpiresAt: time.Now().Add(time.Hour),
-			IssuedAt:  time.Now(),
-			NotBefore: time.Now(),
-			Extra:     make(map[string]interface{}),
+// returns a valid JWT type. The JWTClaims.ExpiresAt time is intentionally
+// left empty to ensure it is pulled from the session's ExpiresAt map for
+// the given fosite.TokenType.
+var jwtValidCase = func(tokenType fosite.TokenType) *fosite.Request {
+	return &fosite.Request{
+		Client: &fosite.DefaultClient{
+			Secret: []byte("foobarfoobarfoobarfoobar"),
 		},
-		JWTHeader: &jwt.Headers{
-			Extra: make(map[string]interface{}),
+		Session: &JWTSession{
+			JWTClaims: &jwt.JWTClaims{
+				Issuer:    "fosite",
+				Subject:   "peter",
+				Audience:  "group0",
+				IssuedAt:  time.Now(),
+				NotBefore: time.Now(),
+				Extra:     make(map[string]interface{}),
+			},
+			JWTHeader: &jwt.Headers{
+				Extra: make(map[string]interface{}),
+			},
+			ExpiresAt: map[fosite.TokenType]time.Time{
+				tokenType: time.Now().Add(time.Hour),
+			},
 		},
-	},
+	}
 }
 
-var jwtExpiredCase = fosite.Request{
-	Client: &fosite.DefaultClient{
-		Secret: []byte("foobarfoobarfoobarfoobar"),
-	},
-	Session: &JWTSession{
-		JWTClaims: &jwt.JWTClaims{
-			Issuer:    "fosite",
-			Subject:   "peter",
-			Audience:  "group0",
-			ExpiresAt: time.Now().Add(-time.Hour),
-			IssuedAt:  time.Now(),
-			NotBefore: time.Now(),
-			Extra:     make(map[string]interface{}),
+// returns an expired JWT type. The JWTClaims.ExpiresAt time is intentionally
+// left empty to ensure it is pulled from the session's ExpiresAt map for
+// the given fosite.TokenType.
+var jwtExpiredCase = func(tokenType fosite.TokenType) *fosite.Request {
+	return &fosite.Request{
+		Client: &fosite.DefaultClient{
+			Secret: []byte("foobarfoobarfoobarfoobar"),
 		},
-		JWTHeader: &jwt.Headers{
-			Extra: make(map[string]interface{}),
+		Session: &JWTSession{
+			JWTClaims: &jwt.JWTClaims{
+				Issuer:    "fosite",
+				Subject:   "peter",
+				Audience:  "group0",
+				IssuedAt:  time.Now(),
+				NotBefore: time.Now(),
+				Extra:     make(map[string]interface{}),
+			},
+			JWTHeader: &jwt.Headers{
+				Extra: make(map[string]interface{}),
+			},
+			ExpiresAt: map[fosite.TokenType]time.Time{
+				tokenType: time.Now().Add(-time.Hour),
+			},
 		},
-	},
+	}
 }
 
 func TestAccessToken(t *testing.T) {
 	for _, c := range []struct {
-		r    fosite.Request
+		r    *fosite.Request
 		pass bool
 	}{
 		{
-			r:    jwtValidCase,
+			r:    jwtValidCase(fosite.AccessToken),
 			pass: true,
 		},
 		{
-			r:    jwtExpiredCase,
+			r:    jwtExpiredCase(fosite.AccessToken),
 			pass: false,
 		},
 	} {
-		token, signature, err := j.GenerateAccessToken(nil, &c.r)
+		token, signature, err := j.GenerateAccessToken(nil, c.r)
 		assert.Nil(t, err, "%s", err)
 		assert.Equal(t, strings.Split(token, ".")[2], signature)
 
 		validate := j.signature(token)
-		err = j.ValidateAccessToken(nil, &c.r, token)
+		err = j.ValidateAccessToken(nil, c.r, token)
 		if c.pass {
 			assert.Nil(t, err, "%s", err)
 			assert.Equal(t, signature, validate)
@@ -87,36 +101,36 @@ func TestAccessToken(t *testing.T) {
 }
 
 func TestRefreshToken(t *testing.T) {
-	token, signature, err := j.GenerateRefreshToken(nil, &jwtValidCase)
+	token, signature, err := j.GenerateRefreshToken(nil, jwtValidCase(fosite.RefreshToken))
 	assert.Nil(t, err, "%s", err)
 	assert.Equal(t, strings.Split(token, ".")[2], signature)
 
 	validate := j.signature(token)
-	err = j.ValidateRefreshToken(nil, &jwtValidCase, token)
+	err = j.ValidateRefreshToken(nil, jwtValidCase(fosite.RefreshToken), token)
 	assert.Nil(t, err, "%s", err)
 	assert.Equal(t, signature, validate)
 }
 
 func TestGenerateAuthorizeCode(t *testing.T) {
 	for _, c := range []struct {
-		r    fosite.Request
+		r    *fosite.Request
 		pass bool
 	}{
 		{
-			r:    jwtValidCase,
+			r:    jwtValidCase(fosite.AuthorizeCode),
 			pass: true,
 		},
 		{
-			r:    jwtExpiredCase,
+			r:    jwtExpiredCase(fosite.AuthorizeCode),
 			pass: false,
 		},
 	} {
-		token, signature, err := j.GenerateAuthorizeCode(nil, &c.r)
+		token, signature, err := j.GenerateAuthorizeCode(nil, c.r)
 		assert.Nil(t, err, "%s", err)
 		assert.Equal(t, strings.Split(token, ".")[2], signature)
 
 		validate := j.signature(token)
-		err = j.ValidateAuthorizeCode(nil, &c.r, token)
+		err = j.ValidateAuthorizeCode(nil, c.r, token)
 		if c.pass {
 			assert.Nil(t, err, "%s", err)
 			assert.Equal(t, signature, validate)


### PR DESCRIPTION
Fixes https://github.com/ory-am/fosite/issues/120. The JWT strategy now uses the `ExpiresAt` map introduced in `0.5.0` to set expirations by `fosite.TokenType`. Previously the expiration was the same for all token types based on the `JWTClaims.ExpiresAt` field.

Signed-off-by: Cristian Graziano <cristiangraz@users.noreply.github.com>