### PR TITLE
Introspection endpoint responds to invalid requests appropriately

### DIFF
--- a/introspection_response_writer.go
+++ b/introspection_response_writer.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// WriteIntrospectionResponse responds with token metadata discovered by token introspection as defined in
+// WriteIntrospectionError responds with token metadata discovered by token introspection as defined in
 // https://tools.ietf.org/search/rfc7662#section-2.2
 //
 // If the protected resource uses OAuth 2.0 client credentials to
@@ -33,7 +33,8 @@ func (f *Fosite) WriteIntrospectionError(rw http.ResponseWriter, err error) {
 		return
 	}
 
-	if errors.Cause(err) == ErrRequestUnauthorized {
+	switch errors.Cause(err) {
+	case ErrInvalidRequest, ErrRequestUnauthorized:
 		writeJsonError(rw, err)
 		return
 	}
@@ -43,7 +44,7 @@ func (f *Fosite) WriteIntrospectionError(rw http.ResponseWriter, err error) {
 	}{Active: false})
 }
 
-// WriteIntrospectionError responds with an error if token introspection failed as defined in
+// WriteIntrospectionResponse responds with an error if token introspection failed as defined in
 // https://tools.ietf.org/search/rfc7662#section-2.3
 //
 // The server responds with a JSON object [RFC7159] in "application/


### PR DESCRIPTION
This PR improves the behavior of the OAuth2 Introspection endpoint to respond with a more appropriate error message when the request is invalid. Currently, fosite responds to all requests other than those that are classified as "unauthorized" with an HTTP status code of 200 and body of `{"active":"false"}`.

While the spec doesn't define what to do in the case of an invalid request (at least not that I could find), I can't think of a reason that one would want to obscure the difference between an invalid request and some other kind of error. It definitely has the potential to be confusing though when one is developing an application! We ran into this case when accidentally using `GET` instead of `POST` on this endpoint.

[1] https://tools.ietf.org/html/rfc7662#section-2.3