### PR TITLE
token/jwt: Allow single element string arrays to be treated as strings

### DIFF
--- a/token/jwt/claims.go
+++ b/token/jwt/claims.go
@@ -19,6 +19,12 @@ func ToString(i interface{}) string {
 		return s
 	}
 
+	if sl, ok := i.([]string); ok {
+		if len(sl) == 1 {
+			return sl[0]
+		}
+	}
+
 	return ""
 }
 


### PR DESCRIPTION
This commit allows `aud` to be passed in as a single element array
during consent validation on Hydra. This fixes
https://github.com/ory-am/hydra/issues/314.

Signed-off-by: Son Dinh <son.dinh@blacksquaremedia.com>