### PR TITLE
RFC6749Error: conform to RFC 6749

### DIFF
--- a/access_error_test.go
+++ b/access_error_test.go
@@ -1,12 +1,16 @@
 package fosite_test
 
 import (
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/ory-am/fosite"
 	. "github.com/ory-am/fosite/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteAccessError(t *testing.T) {
@@ -21,4 +25,37 @@ func TestWriteAccessError(t *testing.T) {
 	rw.EXPECT().Write(gomock.Any())
 
 	f.WriteAccessError(rw, nil, ErrInvalidRequest)
+}
+
+func TestWriteAccessError_RFC6749(t *testing.T) {
+	// https://tools.ietf.org/html/rfc6749#section-5.2
+
+	f := &Fosite{}
+
+	for k, c := range []struct {
+		err  error
+		code string
+	}{
+		{ErrInvalidRequest, "invalid_request"},
+		{ErrInvalidClient, "invalid_client"},
+		{ErrInvalidGrant, "invalid_grant"},
+		{ErrInvalidScope, "invalid_scope"},
+		{ErrUnauthorizedClient, "unauthorized_client"},
+		{ErrUnsupportedGrantType, "unsupported_grant_type"},
+	} {
+		rw := httptest.NewRecorder()
+		f.WriteAccessError(rw, nil, c.err)
+
+		var params struct {
+			Error       string `json:"error"`             // specified by RFC, required
+			Description string `json:"error_description"` // specified by RFC, optional
+		}
+
+		require.NotNil(t, rw.Body, "(%d) %s: nil body", k, c.code)
+		err := json.NewDecoder(rw.Body).Decode(&params)
+		require.NoError(t, err, "(%d) %s", k, c.code)
+
+		assert.Equal(t, c.code, params.Error, "(%d) %s: error", k, c.code)
+		assert.Equal(t, c.err.Error(), params.Description, "(%d) %s: description", k, c.code)
+	}
 }

--- a/errors.go
+++ b/errors.go
@@ -58,8 +58,8 @@ const (
 )
 
 type RFC6749Error struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name        string `json:"error"`
+	Description string `json:"error_description"`
 	Hint        string `json:"-"`
 	StatusCode  int    `json:"statusCode"`
 	Debug       string `json:"-"`


### PR DESCRIPTION
Section 5.2 specifies the parameters for access error responses; the "error" and "error_description" parameters are misnamed ("name" and "description").

https://tools.ietf.org/html/rfc6749#section-5.2

The patch maintains backwards compatibility by marshaling both the existing fields, and the fields required by the RFC.